### PR TITLE
Code modernization and cleanup

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,15 @@
+﻿<Project>
+  <PropertyGroup>
+    <Authors>ankane</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/pgvector/pgvector-dotnet</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
+    <AnalysisLevel>latest</AnalysisLevel>
+  </PropertyGroup>
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,16 @@
+<Project>
+
+  <ItemGroup>
+    <PackageVersion Include="Npgsql" Version="7" />
+    <PackageVersion Include="Dapper" Version="2.0.4" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7" />
+
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="coverlet.collector" Version="3.1.2" />
+    <PackageVersion Include="EFCore.NamingConventions" Version="7.0.2" />
+
+  </ItemGroup>
+
+</Project>

--- a/Pgvector.sln
+++ b/Pgvector.sln
@@ -15,6 +15,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pgvector.Dapper", "src\Pgve
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pgvector.EntityFrameworkCore", "src\Pgvector.EntityFrameworkCore\Pgvector.EntityFrameworkCore.csproj", "{4493B7D8-112B-4867-9373-C08B6F996875}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C598AACF-EE58-4073-B844-A86238C82D1F}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+		Directory.Packages.props = Directory.Packages.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Pgvector.Dapper/Pgvector.Dapper.csproj
+++ b/src/Pgvector.Dapper/Pgvector.Dapper.csproj
@@ -3,11 +3,7 @@
   <PropertyGroup>
     <PackageId>Pgvector.Dapper</PackageId>
     <Version>0.1.1</Version>
-    <Authors>ankane</Authors>
     <Description>pgvector support for Dapper</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/pgvector/pgvector-dotnet</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
@@ -16,8 +12,7 @@
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" />
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <ProjectReference Include="..\Pgvector\Pgvector.csproj" />
-    <PackageReference Include="Dapper" Version="2.0.4" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8" />
+    <PackageReference Include="Dapper" />
   </ItemGroup>
 
 </Project>

--- a/src/Pgvector.Dapper/VectorTypeHandler.cs
+++ b/src/Pgvector.Dapper/VectorTypeHandler.cs
@@ -1,45 +1,20 @@
 using Dapper;
-using Pgvector;
 using System;
 using System.Data;
-using System.Data.SqlClient;
 
-namespace Pgvector.Dapper
+namespace Pgvector.Dapper;
+
+public class VectorTypeHandler : SqlMapper.TypeHandler<Vector>
 {
-    public class VectorTypeHandler : SqlMapper.TypeHandler<Vector>
-    {
-        public override Vector Parse(object value)
+    public override Vector Parse(object value)
+        => value switch
         {
-            if (value == null || value is DBNull)
-            {
-                return null;
-            }
-            else if (value is Vector vec)
-            {
-                return vec;
-            }
-            else
-            {
-                var s = value.ToString();
-                return s != null ? new Vector(s) : null;
-            }
-        }
+            Vector vec => vec,
+            null or DBNull => null!,
 
-        public override void SetValue(IDbDataParameter parameter, Vector value)
-        {
-            if (value == null)
-            {
-                parameter.Value = DBNull.Value;
-            }
-            else
-            {
-                parameter.Value = value;
-            }
+            _ => value.ToString() is string s ? new Vector(s) : null!
+        };
 
-            if (parameter is SqlParameter sqlParameter)
-            {
-                sqlParameter.UdtTypeName = "vector";
-            }
-        }
-    }
+    public override void SetValue(IDbDataParameter parameter, Vector value)
+        => parameter.Value = value == null ? DBNull.Value : value;
 }

--- a/src/Pgvector.EntityFrameworkCore/Pgvector.EntityFrameworkCore.csproj
+++ b/src/Pgvector.EntityFrameworkCore/Pgvector.EntityFrameworkCore.csproj
@@ -3,11 +3,7 @@
   <PropertyGroup>
     <PackageId>Pgvector.EntityFrameworkCore</PackageId>
     <Version>0.1.1</Version>
-    <Authors>ankane</Authors>
     <Description>pgvector support for Entity Framework Core</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/pgvector/pgvector-dotnet</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -18,7 +14,7 @@
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" />
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <ProjectReference Include="..\Pgvector\Pgvector.csproj" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
 
 </Project>

--- a/src/Pgvector.EntityFrameworkCore/VectorDbContextOptionsBuilderExtensions.cs
+++ b/src/Pgvector.EntityFrameworkCore/VectorDbContextOptionsBuilderExtensions.cs
@@ -9,8 +9,11 @@ public static class VectorDbContextOptionsBuilderExtensions
 {
     public static NpgsqlDbContextOptionsBuilder UseVector(this NpgsqlDbContextOptionsBuilder optionsBuilder)
     {
+        // Npgsql's GlobalTypeMapper is obsolete
         // not ideal, but how Npgsql.EntityFrameworkCore.PostgreSQL does it
+#pragma warning disable CS0618
         NpgsqlConnection.GlobalTypeMapper.UseVector();
+#pragma warning restore CS0618
 
         var coreOptionsBuilder = ((IRelationalDbContextOptionsBuilderInfrastructure)optionsBuilder).OptionsBuilder;
 

--- a/src/Pgvector.EntityFrameworkCore/VectorTypeMappingSourcePlugin.cs
+++ b/src/Pgvector.EntityFrameworkCore/VectorTypeMappingSourcePlugin.cs
@@ -5,12 +5,7 @@ namespace Pgvector.EntityFrameworkCore;
 public class VectorTypeMappingSourcePlugin : IRelationalTypeMappingSourcePlugin
 {
     public RelationalTypeMapping? FindMapping(in RelationalTypeMappingInfo mappingInfo)
-    {
-        if (mappingInfo.ClrType == typeof(Vector))
-        {
-            return new VectorTypeMapping(mappingInfo.StoreTypeName ?? "vector");
-        }
-
-        return null;
-    }
+        => mappingInfo.ClrType == typeof(Vector)
+            ? new VectorTypeMapping(mappingInfo.StoreTypeName ?? "vector")
+            : null;
 }

--- a/src/Pgvector/Npgsql/VectorExtensions.cs
+++ b/src/Pgvector/Npgsql/VectorExtensions.cs
@@ -1,13 +1,12 @@
 using Npgsql.TypeMapping;
 
-namespace Pgvector.Npgsql
+namespace Pgvector.Npgsql;
+
+public static class VectorExtensions
 {
-    public static class VectorExtensions
+    public static INpgsqlTypeMapper UseVector(this INpgsqlTypeMapper mapper)
     {
-        public static INpgsqlTypeMapper UseVector(this INpgsqlTypeMapper mapper)
-        {
-            mapper.AddTypeResolverFactory(new VectorTypeHandlerResolverFactory());
-            return mapper;
-        }
+        mapper.AddTypeResolverFactory(new VectorTypeHandlerResolverFactory());
+        return mapper;
     }
 }

--- a/src/Pgvector/Npgsql/VectorHandler.cs
+++ b/src/Pgvector/Npgsql/VectorHandler.cs
@@ -7,77 +7,76 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Pgvector.Npgsql
+namespace Pgvector.Npgsql;
+
+public class VectorHandler : NpgsqlTypeHandler<Vector>
 {
-    public partial class VectorHandler : NpgsqlTypeHandler<Vector>
+    public VectorHandler(PostgresType pgType) : base(pgType) { }
+
+    public override async ValueTask<Vector> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription? fieldDescription = null)
     {
-        public VectorHandler(PostgresType pgType) : base(pgType) { }
+        await buf.Ensure(2 * sizeof(ushort), async);
+        var dim = buf.ReadUInt16();
+        var unused = buf.ReadUInt16();
+        if (unused != 0)
+            throw new InvalidCastException("expected unused to be 0");
 
-        public override async ValueTask<Vector> Read(NpgsqlReadBuffer buf, int len, bool async, FieldDescription fieldDescription = null)
+        var vec = new float[dim];
+        for (var i = 0; i < dim; i++)
         {
-            await buf.Ensure(2 * sizeof(ushort), async);
-            var dim = buf.ReadUInt16();
-            var unused = buf.ReadUInt16();
-            if (unused != 0)
-                throw new InvalidCastException("expected unused to be 0");
-
-            var vec = new float[dim];
-            for (var i = 0; i < dim; i++)
-            {
-                await buf.Ensure(sizeof(float), async);
-                vec[i] = buf.ReadSingle();
-            }
-
-            return new Vector(vec);
+            await buf.Ensure(sizeof(float), async);
+            vec[i] = buf.ReadSingle();
         }
 
-        public override int ValidateAndGetLength(Vector value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
-            => sizeof(UInt16) * 2 + sizeof(Single) * value.ToArray().Length;
+        return new Vector(vec);
+    }
 
-        public override async Task Write(
-            Vector value,
-            NpgsqlWriteBuffer buf,
-            NpgsqlLengthCache lengthCache,
-            NpgsqlParameter parameter,
-            bool async,
-            CancellationToken cancellationToken = default)
+    public override int ValidateAndGetLength(Vector value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+        => sizeof(UInt16) * 2 + sizeof(Single) * value.ToArray().Length;
+
+    public override async Task Write(
+        Vector value,
+        NpgsqlWriteBuffer buf,
+        NpgsqlLengthCache? lengthCache,
+        NpgsqlParameter? parameter,
+        bool async,
+        CancellationToken cancellationToken = default)
+    {
+        if (buf.WriteSpaceLeft < sizeof(ushort) * 2)
+            await buf.Flush(async, cancellationToken);
+
+        var vec = value.ToArray();
+        var dim = vec.Length;
+        buf.WriteUInt16(Convert.ToUInt16(dim));
+        buf.WriteUInt16(0);
+
+        for (int i = 0; i < dim; i++)
         {
-            if (buf.WriteSpaceLeft < sizeof(ushort) * 2)
+            if (buf.WriteSpaceLeft < sizeof(float))
                 await buf.Flush(async, cancellationToken);
-
-            var vec = value.ToArray();
-            var dim = vec.Length;
-            buf.WriteUInt16(Convert.ToUInt16(dim));
-            buf.WriteUInt16(0);
-
-            for (int i = 0; i < dim; i++)
-            {
-                if (buf.WriteSpaceLeft < sizeof(float))
-                    await buf.Flush(async, cancellationToken);
-                buf.WriteSingle(vec[i]);
-            }
+            buf.WriteSingle(vec[i]);
         }
+    }
 
-        public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache lengthCache, NpgsqlParameter parameter)
-        {
-            if (value is Vector converted)
-                return ValidateAndGetLength(converted, ref lengthCache, parameter);
+    public override int ValidateObjectAndGetLength(object value, ref NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter)
+    {
+        if (value is Vector converted)
+            return ValidateAndGetLength(converted, ref lengthCache, parameter);
 
-            if (value is DBNull || value is null)
-                return 0;
+        if (value is DBNull or null)
+            return 0;
 
-            throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type VectorHandler");
-        }
+        throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type VectorHandler");
+    }
 
-        public override Task WriteObjectWithLength(object value, NpgsqlWriteBuffer buf, NpgsqlLengthCache lengthCache, NpgsqlParameter parameter, bool async, CancellationToken cancellationToken = default)
-        {
-            if (value is Vector converted)
-                return WriteWithLength(converted, buf, lengthCache, parameter, async, cancellationToken);
+    public override Task WriteObjectWithLength(object? value, NpgsqlWriteBuffer buf, NpgsqlLengthCache? lengthCache, NpgsqlParameter? parameter, bool async, CancellationToken cancellationToken = default)
+    {
+        if (value is Vector converted)
+            return WriteWithLength(converted, buf, lengthCache, parameter, async, cancellationToken);
 
-            if (value is DBNull || value is null)
-                return WriteWithLength(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken);
+        if (value is DBNull or null)
+            return WriteWithLength(DBNull.Value, buf, lengthCache, parameter, async, cancellationToken);
 
-            throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type VectorHandler");
-        }
+        throw new InvalidCastException($"Can't write CLR type {value.GetType()} with handler type VectorHandler");
     }
 }

--- a/src/Pgvector/Npgsql/VectorTypeHandlerResolverFactory.cs
+++ b/src/Pgvector/Npgsql/VectorTypeHandlerResolverFactory.cs
@@ -2,17 +2,16 @@ using Npgsql.Internal;
 using Npgsql.Internal.TypeHandling;
 using System;
 
-namespace Pgvector.Npgsql
+namespace Pgvector.Npgsql;
+
+public class VectorTypeHandlerResolverFactory : TypeHandlerResolverFactory
 {
-    public class VectorTypeHandlerResolverFactory : TypeHandlerResolverFactory
-    {
-        public override TypeHandlerResolver Create(NpgsqlConnector connector)
-            => new VectorTypeHandlerResolver(connector);
+    public override TypeHandlerResolver Create(NpgsqlConnector connector)
+        => new VectorTypeHandlerResolver(connector);
 
-        public override string GetDataTypeNameByClrType(Type type)
-            => VectorTypeHandlerResolver.ClrTypeToDataTypeName(type);
+    public override string? GetDataTypeNameByClrType(Type type)
+        => VectorTypeHandlerResolver.ClrTypeToDataTypeName(type);
 
-        public override TypeMappingInfo GetMappingByDataTypeName(string dataTypeName)
-            => VectorTypeHandlerResolver.DoGetMappingByDataTypeName(dataTypeName);
-    }
+    public override TypeMappingInfo? GetMappingByDataTypeName(string dataTypeName)
+        => VectorTypeHandlerResolver.DoGetMappingByDataTypeName(dataTypeName);
 }

--- a/src/Pgvector/Pgvector.csproj
+++ b/src/Pgvector/Pgvector.csproj
@@ -3,11 +3,7 @@
   <PropertyGroup>
     <PackageId>Pgvector</PackageId>
     <Version>0.1.3</Version>
-    <Authors>ankane</Authors>
     <Description>pgvector support for C#</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/pgvector/pgvector-dotnet</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
@@ -15,7 +11,7 @@
   <ItemGroup>
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" />
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-    <PackageReference Include="Npgsql" Version="7" />
+    <PackageReference Include="Npgsql" />
   </ItemGroup>
 
 </Project>

--- a/src/Pgvector/Vector.cs
+++ b/src/Pgvector/Vector.cs
@@ -2,30 +2,29 @@ using System;
 using System.Globalization;
 using System.Linq;
 
-namespace Pgvector
+namespace Pgvector;
+
+public class Vector
 {
-    public class Vector
+    private float[] vec;
+
+    public Vector(float[] v)
     {
-        private float[] vec;
+        vec = v;
+    }
 
-        public Vector(float[] v)
-        {
-            vec = v;
-        }
+    public Vector(string s)
+    {
+        vec = Array.ConvertAll(s.Substring(1, s.Length - 2).Split(','), v => float.Parse(v, CultureInfo.InvariantCulture));
+    }
 
-        public Vector(string s)
-        {
-            vec = Array.ConvertAll(s.Substring(1, s.Length - 2).Split(','), v => float.Parse(v, CultureInfo.InvariantCulture));
-        }
+    public override string ToString()
+    {
+        return string.Concat("[", string.Join(",", vec.Select(v => v.ToString(CultureInfo.InvariantCulture))), "]");
+    }
 
-        public override string ToString()
-        {
-            return string.Concat("[", string.Join(",", vec.Select(v => v.ToString(CultureInfo.InvariantCulture))), "]");
-        }
-
-        public float[] ToArray()
-        {
-            return vec;
-        }
+    public float[] ToArray()
+    {
+        return vec;
     }
 }

--- a/tests/Pgvector.Tests/DapperTests.cs
+++ b/tests/Pgvector.Tests/DapperTests.cs
@@ -1,6 +1,4 @@
-using Xunit;
 using Dapper;
-using Npgsql;
 using Pgvector.Dapper;
 using Pgvector.Npgsql;
 

--- a/tests/Pgvector.Tests/EntityFrameworkCoreTests.cs
+++ b/tests/Pgvector.Tests/EntityFrameworkCoreTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 using Microsoft.EntityFrameworkCore;
 using Pgvector.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations.Schema;

--- a/tests/Pgvector.Tests/NpgsqlTests.cs
+++ b/tests/Pgvector.Tests/NpgsqlTests.cs
@@ -1,5 +1,3 @@
-using Xunit;
-using Npgsql;
 using Pgvector.Npgsql;
 
 namespace Pgvector.Tests;

--- a/tests/Pgvector.Tests/Pgvector.Tests.csproj
+++ b/tests/Pgvector.Tests/Pgvector.Tests.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -25,7 +25,11 @@
     <ProjectReference Include="..\..\src\Pgvector\Pgvector.csproj" />
     <ProjectReference Include="..\..\src\Pgvector.Dapper\Pgvector.Dapper.csproj" />
     <ProjectReference Include="..\..\src\Pgvector.EntityFrameworkCore\Pgvector.EntityFrameworkCore.csproj" />
-    <PackageReference Include="EFCore.NamingConventions" Version="7.0.2" />
+    <PackageReference Include="EFCore.NamingConventions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Using Include="Npgsql" />
+    <Using Include="Xunit" />
+  </ItemGroup>
 </Project>

--- a/tests/Pgvector.Tests/Usings.cs
+++ b/tests/Pgvector.Tests/Usings.cs
@@ -1,1 +1,0 @@
-global using Xunit;


### PR DESCRIPTION
This does various mechanical C# language and build modernizations to bring the codebase to the latest best practices etc.; it contains no actual functional code changes. I know it seems like a big PR, but almost all changes are simply due to the indentation change because of the use of file-scoped namespaces.

Changes:

* Move common build properties to Directory.Build.props
* Switch to centralized package version management (Directory.Packages.props)
* Switch to the latest C# LangVersion
* Turn on C# nullable reference types and annotate everything
* Use file-scoped namespaces
* Various other minor modernizations

