### PR TITLE
Change namespace for entry-point extension methods

### DIFF
--- a/src/Pgvector.EntityFrameworkCore/VectorDbContextOptionsBuilderExtensions.cs
+++ b/src/Pgvector.EntityFrameworkCore/VectorDbContextOptionsBuilderExtensions.cs
@@ -1,9 +1,10 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Npgsql;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+using Pgvector.EntityFrameworkCore;
 using Pgvector.Npgsql;
 
-namespace Pgvector.EntityFrameworkCore;
+namespace Microsoft.EntityFrameworkCore;
 
 public static class VectorDbContextOptionsBuilderExtensions
 {

--- a/src/Pgvector/Npgsql/VectorExtensions.cs
+++ b/src/Pgvector/Npgsql/VectorExtensions.cs
@@ -1,6 +1,7 @@
 using Npgsql.TypeMapping;
+using Pgvector.Npgsql;
 
-namespace Pgvector.Npgsql;
+namespace Npgsql;
 
 public static class VectorExtensions
 {


### PR DESCRIPTION
@ankane this change the namespaces of the UseVector() methods - both Npgsql and EF - to Npgsql and Microsoft.EntityFramework respectively. Since these are the main namespaces of the base packages, this means users no longer have to import Pgvector.Npgsql and Pgvector.EntityFrameworkCore in their code in order to use pgvector. This is how plugins generally do it at both levels.

Note that this targets npgsql8-v2 to avoid breaking the current release (v8 will contain much more serious breaking changes anyway and there will be no compatibility mixing major versions).