### PR TITLE
Define equality/GetHashCode for the Vector class

### DIFF
--- a/src/Pgvector/Npgsql/VectorConverter.cs
+++ b/src/Pgvector/Npgsql/VectorConverter.cs
@@ -57,8 +57,8 @@ public class VectorConverter : PgStreamingConverter<Vector>
         if (writer.ShouldFlush(sizeof(ushort) * 2))
             writer.Flush();
 
-        var vec = value.vec;
-        var dim = vec.Length;
+        var span = value.Memory.Span;
+        var dim = span.Length;
         writer.WriteUInt16(Convert.ToUInt16(dim));
         writer.WriteUInt16(0);
 
@@ -66,7 +66,7 @@ public class VectorConverter : PgStreamingConverter<Vector>
         {
             if (writer.ShouldFlush(sizeof(float)))
                 writer.Flush();
-            writer.WriteFloat(vec.Span[i]);
+            writer.WriteFloat(span[i]);
         }
     }
 
@@ -76,8 +76,8 @@ public class VectorConverter : PgStreamingConverter<Vector>
         if (writer.ShouldFlush(sizeof(ushort) * 2))
             await writer.FlushAsync(cancellationToken);
 
-        var vec = value.vec;
-        var dim = vec.Length;
+        var memory = value.Memory;
+        var dim = memory.Length;
         writer.WriteUInt16(Convert.ToUInt16(dim));
         writer.WriteUInt16(0);
 
@@ -85,7 +85,7 @@ public class VectorConverter : PgStreamingConverter<Vector>
         {
             if (writer.ShouldFlush(sizeof(float)))
                 await writer.FlushAsync(cancellationToken);
-            writer.WriteFloat(vec.Span[i]);
+            writer.WriteFloat(memory.Span[i]);
         }
     }
 }

--- a/src/Pgvector/Vector.cs
+++ b/src/Pgvector/Vector.cs
@@ -20,7 +20,7 @@ public class Vector : IEquatable<Vector>
     public float[] ToArray()
         => Memory.ToArray();
 
-    public bool Equals(Vector other)
+    public bool Equals(Vector? other)
     {
         if (other is null || other.Memory.Length != Memory.Length)
         {

--- a/src/Pgvector/Vector.cs
+++ b/src/Pgvector/Vector.cs
@@ -4,22 +4,60 @@ using System.Linq;
 
 namespace Pgvector;
 
-public class Vector
+public class Vector : IEquatable<Vector>
 {
-    internal ReadOnlyMemory<float> vec;
+    public ReadOnlyMemory<float> Memory { get; }
 
     public Vector(ReadOnlyMemory<float> v)
-        => vec = v;
-
-    public Vector(float[] v)
-        => vec = new ReadOnlyMemory<float>(v);
+        => Memory = v;
 
     public Vector(string s)
         => new Vector(Array.ConvertAll(s.Substring(1, s.Length - 2).Split(','), v => float.Parse(v, CultureInfo.InvariantCulture)));
 
     public override string ToString()
-        => string.Concat("[", string.Join(",", vec.ToArray().Select(v => v.ToString(CultureInfo.InvariantCulture))), "]");
+        => string.Concat("[", string.Join(",", Memory.ToArray().Select(v => v.ToString(CultureInfo.InvariantCulture))), "]");
 
     public float[] ToArray()
-        => vec.ToArray();
+        => Memory.ToArray();
+
+    public bool Equals(Vector other)
+    {
+        if (other is null || other.Memory.Length != Memory.Length)
+        {
+            return false;
+        }
+
+        var span1 = Memory.Span;
+        var span2 = other.Memory.Span;
+
+        for (var i = 0; i < Memory.Length; i++)
+        {
+            if (span1[i] != span2[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override bool Equals(object? obj)
+        => obj is Vector vector && Equals(vector);
+
+    public static bool operator ==(Vector x, Vector y) => x.Equals(y);
+    public static bool operator !=(Vector x, Vector y) => !(x == y);
+
+    public override int GetHashCode()
+    {
+        var hashCode = new HashCode();
+
+        var span = Memory.Span;
+
+        for (var i = 0; i < span.Length; i++)
+        {
+            hashCode.Add(span[i]);
+        }
+
+        return hashCode.ToHashCode();
+    }
 }

--- a/src/Pgvector/Vector.cs
+++ b/src/Pgvector/Vector.cs
@@ -21,25 +21,7 @@ public class Vector : IEquatable<Vector>
         => Memory.ToArray();
 
     public bool Equals(Vector? other)
-    {
-        if (other is null || other.Memory.Length != Memory.Length)
-        {
-            return false;
-        }
-
-        var span1 = Memory.Span;
-        var span2 = other.Memory.Span;
-
-        for (var i = 0; i < Memory.Length; i++)
-        {
-            if (span1[i] != span2[i])
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
+        => other is not null && Memory.Span.SequenceEqual(other.Memory.Span);
 
     public override bool Equals(object? obj)
         => obj is Vector vector && Equals(vector);


### PR DESCRIPTION
@ankane here's a change adding equality/hash code logic to the Vector class.

Note that this implementation compares the `float[]` reference and **not** its contents, so two Vector instances with identical float contents are **not** considered equal.

I actually think that true value semantics (i.e. comparing the data) would be more useful. However, although the array itself is currently immutable (I added `readonly` to vec to make that explicit), its contents are mutable (since the full array is exposed rather than e.g. `ReadOnlyMemory<float>`). This means that Vector is currently a mutable type, and so it's a bad idea to define GetHashCode() over the contents.

IMHO ideally Vector would be fully immutable, accepting and exposing only `ReadOnlyMemory<float>`; this would allow full value semantics (i.e. equality and hash code based on the data contents), and would incidentally also allow users to define Vectors over slices of data/native memory (this is a general advantage of ReadOnlyMemory over working only with arrays). FYI we're trying to more or less standardize on `ReadOnlyMemory<float>` in general as the representation for vector databases (e.g. in the [SemanticKernel project](https://github.com/microsoft/semantic-kernel)). Let me know if you want to take it in this direction.

~One unrelated note: I'd recommend changing the ToArray() method; there are many places in .NET where ToArray() means that an array **copy** is created (e.g. [IEnumerable.ToArray](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.toarray?view=net-7.0#system-linq-enumerable-toarray-1(system-collections-generic-ienumerable((-0))))), whereas here it simply returns the vector (this confused me as well).~