### PR TITLE
 - re-adding support for net6 and net7 to Pgvector.EntityFrameworkCore

### DIFF
--- a/src/Pgvector.EntityFrameworkCore/Pgvector.EntityFrameworkCore.csproj
+++ b/src/Pgvector.EntityFrameworkCore/Pgvector.EntityFrameworkCore.csproj
@@ -1,25 +1,36 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <PackageId>Pgvector.EntityFrameworkCore</PackageId>
-    <Version>0.2.0</Version>
-    <Authors>ankane</Authors>
-    <Description>pgvector support for Entity Framework Core</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/pgvector/pgvector-dotnet</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+	<PropertyGroup>
+		<PackageId>Pgvector.EntityFrameworkCore</PackageId>
+		<Version>0.2.1</Version>
+		<Authors>ankane</Authors>
+		<Description>pgvector support for Entity Framework Core</Description>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/pgvector/pgvector-dotnet</PackageProjectUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
+		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-    <ProjectReference Include="..\Pgvector\Pgvector.csproj" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" />
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+		<ProjectReference Include="..\Pgvector\Pgvector.csproj" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.*" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.*" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.*" />
+	</ItemGroup>
 
 </Project>

--- a/src/Pgvector.EntityFrameworkCore/VectorDbFunctionsTranslatorPlugin.cs
+++ b/src/Pgvector.EntityFrameworkCore/VectorDbFunctionsTranslatorPlugin.cs
@@ -78,6 +78,15 @@ public class VectorDbFunctionsTranslatorPlugin : IMethodCallTranslatorPlugin
             {
                 var resultTypeMapping = _typeMappingSource.FindMapping(method.ReturnType)!;
 
+#if NET6_0 || NET7_0
+                return new PostgresUnknownBinaryExpression(
+                    left: _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[0]),
+                    right: _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[1]),
+                    binaryOperator: vectorOperator,
+                    type: resultTypeMapping.ClrType,
+                    typeMapping: resultTypeMapping
+                );
+#else
                 return new PgUnknownBinaryExpression(
                     left: _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[0]),
                     right: _sqlExpressionFactory.ApplyDefaultTypeMapping(arguments[1]),
@@ -85,6 +94,8 @@ public class VectorDbFunctionsTranslatorPlugin : IMethodCallTranslatorPlugin
                     type: resultTypeMapping.ClrType,
                     typeMapping: resultTypeMapping
                 );
+
+#endif
             }
 
             return null;


### PR DESCRIPTION
Hey, thanks for making this.

However in 0.2 support for net7 and net8 was broken. So this fixes it again :)