### PR TITLE
[pgvector] Target netstandard2.0 again

### DIFF
--- a/src/Pgvector.Dapper/HalfvecTypeHandler.cs
+++ b/src/Pgvector.Dapper/HalfvecTypeHandler.cs
@@ -6,6 +6,8 @@ using System.Data.SqlClient;
 
 namespace Pgvector.Dapper;
 
+#if NET5_0_OR_GREATER
+
 public class HalfvecTypeHandler : SqlMapper.TypeHandler<HalfVector?>
 {
     public override HalfVector? Parse(object value)
@@ -26,3 +28,5 @@ public class HalfvecTypeHandler : SqlMapper.TypeHandler<HalfVector?>
         }
     }
 }
+
+#endif

--- a/src/Pgvector.Dapper/Pgvector.Dapper.csproj
+++ b/src/Pgvector.Dapper/Pgvector.Dapper.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/pgvector/pgvector-dotnet</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net462</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -18,7 +18,7 @@
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" />
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <ProjectReference Include="..\Pgvector\Pgvector.csproj" />
-    <PackageReference Include="Dapper" Version="2.0.4" />
+    <PackageReference Include="Dapper" Version="2.0.151" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 

--- a/src/Pgvector.EntityFrameworkCore/Pgvector.EntityFrameworkCore.csproj
+++ b/src/Pgvector.EntityFrameworkCore/Pgvector.EntityFrameworkCore.csproj
@@ -19,7 +19,7 @@
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" />
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <ProjectReference Include="..\Pgvector\Pgvector.csproj" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
   </ItemGroup>
 
 </Project>

--- a/src/Pgvector/HalfVector.cs
+++ b/src/Pgvector/HalfVector.cs
@@ -2,6 +2,8 @@ using System;
 using System.Globalization;
 using System.Linq;
 
+#if NET5_0_OR_GREATER
+
 namespace Pgvector;
 
 public class HalfVector : IEquatable<HalfVector>
@@ -42,3 +44,5 @@ public class HalfVector : IEquatable<HalfVector>
         return hashCode.ToHashCode();
     }
 }
+
+#endif

--- a/src/Pgvector/Npgsql/HalfvecConverter.cs
+++ b/src/Pgvector/Npgsql/HalfvecConverter.cs
@@ -3,6 +3,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Npgsql.Internal;
 
+#if NET5_0_OR_GREATER
+
 namespace Pgvector.Npgsql;
 
 public class HalfvecConverter : PgStreamingConverter<HalfVector>
@@ -89,3 +91,5 @@ public class HalfvecConverter : PgStreamingConverter<HalfVector>
         }
     }
 }
+
+#endif

--- a/src/Pgvector/Npgsql/VectorExtensions.cs
+++ b/src/Pgvector/Npgsql/VectorExtensions.cs
@@ -8,6 +8,7 @@ public static class VectorExtensions
     public static INpgsqlTypeMapper UseVector(this INpgsqlTypeMapper mapper)
     {
         mapper.AddTypeInfoResolverFactory(new VectorTypeInfoResolverFactory());
+
         return mapper;
     }
 }

--- a/src/Pgvector/Npgsql/VectorTypeInfoResolverFactory.cs
+++ b/src/Pgvector/Npgsql/VectorTypeInfoResolverFactory.cs
@@ -21,10 +21,14 @@ public class VectorTypeInfoResolverFactory : PgTypeInfoResolverFactory
         {
             mappings.AddType<Vector>("vector",
                 static (options, mapping, _) => mapping.CreateInfo(options, new VectorConverter()), isDefault: true);
-            mappings.AddType<HalfVector>("halfvec",
-                static (options, mapping, _) => mapping.CreateInfo(options, new HalfvecConverter()), isDefault: true);
             mappings.AddType<SparseVector>("sparsevec",
                 static (options, mapping, _) => mapping.CreateInfo(options, new SparsevecConverter()), isDefault: true);
+
+#if NET5_0_OR_GREATER
+            mappings.AddType<HalfVector>("halfvec",
+                static (options, mapping, _) => mapping.CreateInfo(options, new HalfvecConverter()), isDefault: true);
+#endif
+
             return mappings;
         }
     }
@@ -40,8 +44,12 @@ public class VectorTypeInfoResolverFactory : PgTypeInfoResolverFactory
         static TypeInfoMappingCollection AddMappings(TypeInfoMappingCollection mappings)
         {
             mappings.AddArrayType<Vector>("vector");
-            mappings.AddArrayType<HalfVector>("halfvec");
             mappings.AddArrayType<SparseVector>("sparsevec");
+
+#if NET5_0_OR_GREATER
+            mappings.AddArrayType<HalfVector>("halfvec");
+#endif
+
             return mappings;
         }
     }

--- a/src/Pgvector/Pgvector.csproj
+++ b/src/Pgvector/Pgvector.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/pgvector/pgvector-dotnet</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0;net462</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <NoWarn>NPG9001</NoWarn>
@@ -18,7 +18,7 @@
   <ItemGroup>
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" />
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-    <PackageReference Include="Npgsql" Version="8.0.3" />
+    <PackageReference Include="Npgsql" Version="8.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Pgvector/SparseVector.cs
+++ b/src/Pgvector/SparseVector.cs
@@ -70,7 +70,7 @@ public class SparseVector
 
     public SparseVector(string s)
     {
-        var parts = s.Split('/', 2);
+        var parts = s.Split(['/'], 2);
         var elements = parts[0].Substring(1, parts[0].Length - 2).Split(',');
         var nnz = elements.Length;
         var indices = new int[nnz];
@@ -78,7 +78,7 @@ public class SparseVector
 
         for (int i = 0; i < nnz; i++)
         {
-            var ep = elements[i].Split(':', 2);
+            var ep = elements[i].Split([':'], 2);
             indices[i] = Int32.Parse(ep[0], CultureInfo.InvariantCulture) - 1;
             values[i] = float.Parse(ep[1], CultureInfo.InvariantCulture);
         }


### PR DESCRIPTION
Hey @ankane 👋 

I'm currently working intensively on a .NET abstraction for vector databases - Microsoft.Extensions.VectorData; [see this announcement](https://devblogs.microsoft.com/dotnet/introducing-microsoft-extensions-vector-data/#:~:text=Microsoft.Extensions.VectorData%20is%20a%20set%20of%20core%20.NET%20libraries,of%20C%23%20abstractions%20for%20interacting%20with%20vector%20stores.) (though we've made considerable progress since). PgVector is obviously an important implementation and we're working to make it work nicely there.

One thing we've centralized on is netstandard2.0 and net462 support across the board - wherever possible - to make sure absolutely everyone can do vector search: there are quite a few applications out there still stuck on .NET Framework, and I'm trying to make sure nobody gets left out. I noticed that pgvector 0.3.0 dropped netstandard2.0 support, presumably because of the added support for the .NET Half type, which was only introduced in .NET 5.0.

So here's a PR adding back netstandard2.0, using simple conditional compilation to not have Half there; it's all pretty straightforward and allows .NET Framework users to use float embeddings. Note that it also adds a net462 target explicitly - that's recommended since netstandard2.0 has issues under .NET Framework 4.7.2 ([docs](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting#multi-targeting), under "CONSIDER adding a target for net462 when you're offering a netstandard2.0 target"). None of that complicates the code in any significant way.

Additional things I threw in:

* Bump dependency patch versions
* Simplify to just one Npgsql PgTypeInfoResolverFactory to registers all three vector types, instead of three separate ones (that's what we usually do with plugins).