### PR TITLE
Do not materialize Vector on get size

### DIFF
--- a/src/Pgvector/Npgsql/VectorConverter.cs
+++ b/src/Pgvector/Npgsql/VectorConverter.cs
@@ -50,7 +50,7 @@ public class VectorConverter : PgStreamingConverter<Vector>
     }
 
     public override Size GetSize(SizeContext context, Vector value, ref object? writeState)
-        => sizeof(ushort) * 2 + sizeof(float) * value.ToArray().Length;
+        => sizeof(ushort) * 2 + sizeof(float) * value.Memory.Length;
 
     public override void Write(PgWriter writer, Vector value)
     {


### PR DESCRIPTION
Skip `Vector.ToArray` on getting size