### PR TITLE
Target net10.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,5 @@ jobs:
           make
           sudo make install
       - run: psql -d pgvector_dotnet_test -c "CREATE EXTENSION vector"
-      - run: dotnet test
+      - run: dotnet test -f net8.0
+      - run: dotnet test -f net10.0

--- a/src/Pgvector.EntityFrameworkCore/CHANGELOG.md
+++ b/src/Pgvector.EntityFrameworkCore/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1 (unreleased)
+
+- Added explicit support for .NET 10
+- Updated tests and CI to run on .NET 8 and .NET 10
+
 ## 0.3.0 (2025-12-20)
 
 - Improved type registration

--- a/src/Pgvector.EntityFrameworkCore/Pgvector.EntityFrameworkCore.csproj
+++ b/src/Pgvector.EntityFrameworkCore/Pgvector.EntityFrameworkCore.csproj
@@ -10,7 +10,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -22,7 +22,14 @@
     <None Include="..\..\icon.png" Pack="true" PackagePath="\" />
     <None Include="build\**\*" Pack="true" PackagePath="build" />
     <ProjectReference Include="..\Pgvector\Pgvector.csproj" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Pgvector.EntityFrameworkCore/build/net10.0/Pgvector.EntityFrameworkCore.targets
+++ b/src/Pgvector.EntityFrameworkCore/build/net10.0/Pgvector.EntityFrameworkCore.targets
@@ -1,0 +1,47 @@
+<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <EFCoreNpgsqlPgvectorFile>$(IntermediateOutputPath)EFCoreNpgsqlPgvector$(DefaultLanguageSourceExtension)</EFCoreNpgsqlPgvectorFile>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(Language)' == 'F#'">
+      <Choose>
+        <When Condition="'$(OutputType)' == 'Exe' OR '$(OutputType)' == 'WinExe'">
+          <PropertyGroup>
+            <CodeFragmentItemGroup>CompileBefore</CodeFragmentItemGroup>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <CodeFragmentItemGroup>CompileAfter</CodeFragmentItemGroup>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <CodeFragmentItemGroup>Compile</CodeFragmentItemGroup>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Target Name="AddEFCoreNpgsqlPgvector"
+          BeforeTargets="CoreCompile"
+          DependsOnTargets="PrepareForBuild"
+          Condition="'$(DesignTimeBuild)' != 'True'"
+          Inputs="$(MSBuildAllProjects)"
+          Outputs="$(EFCoreNpgsqlPgvectorFile)">
+    <ItemGroup>
+      <EFCoreNpgsqlPgvectorServices Include="Microsoft.EntityFrameworkCore.Design.DesignTimeServicesReferenceAttribute">
+        <_Parameter1>Pgvector.EntityFrameworkCore.VectorDesignTimeServices, Pgvector.EntityFrameworkCore</_Parameter1>
+        <_Parameter2>Npgsql.EntityFrameworkCore.PostgreSQL</_Parameter2>
+      </EFCoreNpgsqlPgvectorServices>
+    </ItemGroup>
+    <WriteCodeFragment AssemblyAttributes="@(EFCoreNpgsqlPgvectorServices)"
+                       Language="$(Language)"
+                       OutputFile="$(EFCoreNpgsqlPgvectorFile)">
+      <Output TaskParameter="OutputFile" ItemName="$(CodeFragmentItemGroup)" />
+      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
+    </WriteCodeFragment>
+  </Target>
+</Project>
+

--- a/tests/Pgvector.CSharp.Tests/Pgvector.CSharp.Tests.csproj
+++ b/tests/Pgvector.CSharp.Tests/Pgvector.CSharp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
## Explicit support for .NET 10
Updated tests and CI to run on .NET 8 and .NET 10.

### Motivation
For Consumers:
- **Lower upgrade friction:** Users can upgrade their app's Target Framework to .NET 10 with fewer surprises
- **Stability for .NET 8 users:** Teams staying on .NET 8 (LTS) are not forced into immediate ecosystem upgrades
- **Clear support boundaries:** Know exactly which .NET versions are officially supported
- **Warnings:** No need to bypass 
```warning NU1608: Detected package version outside of dependency constraint: Npgsql.EntityFrameworkCore.PostgreSQL 9.0.1 requires EntityFrameworkCore (>= 9.0.0 && < 10.0.0) but version Microsoft.EntityFrameworkCore 10.0.0 was resolved.```
  -  It is a good practice to `TreatWarningsAsErrors`

For Maintainers:
- **Predictable release path:** Creates a clear base for future policy (e.g., eventually dropping .NET 8) with controlled, test-backed transitions
- **Easier API/provider change management:** Conditional deps make it straightforward to support multiple major versions temporarily
- **Better regression detection:** Per-framework CI results catch issues that might only manifest in certain runtimes

Future Extensibility:
- Adding `.NET 11+` only requires updating Target Framework lists and conditionals

## Technical Notes
- All changes are backward-compatible; existing `.NET 8` builds remain unaffected
- No breaking API changes in `Pgvector.EntityFrameworkCore` code
- Both `net8.0` and `net10.0` binaries are included in a single NuGet package

Resolves #57 